### PR TITLE
Fixed a typo in Images.md

### DIFF
--- a/tutorials/learn-html.org/en/Images.md
+++ b/tutorials/learn-html.org/en/Images.md
@@ -45,7 +45,7 @@ attribute - which directs the browser to break the floating effect after the fir
     consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
     Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p> 
 
-    <p class="clear: both">Second paragraph</p>
+    <p style="clear: both">Second paragraph</p>
 
 Exercise
 --------


### PR DESCRIPTION
was using "class" in the second paragraph in the Using the CSS float attribute with images section. I fixed it to style instead.